### PR TITLE
Attempt to fix deprecated function

### DIFF
--- a/pandasqt/models/DataFrameModel.py
+++ b/pandasqt/models/DataFrameModel.py
@@ -414,7 +414,7 @@ class DataFrameModel(QtCore.QAbstractTableModel):
         self.layoutAboutToBeChanged.emit()
         self.sortingAboutToStart.emit()
         column = self._dataFrame.columns[columnId]
-        self._dataFrame.sort(column, ascending=not bool(order), inplace=True)
+        self._dataFrame.sort_values(by=column, ascending=not bool(order), inplace=True)
         self.layoutChanged.emit()
         self.sortingFinished.emit()
 


### PR DESCRIPTION
FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)